### PR TITLE
Simplify tautologies

### DIFF
--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -574,9 +574,9 @@ class NNF(metaclass=abc.ABCMeta):
 
         return neg(self)
 
-    def to_CNF(self, simplify_tautologies: bool = True) -> 'And[Or[Var]]':
+    def to_CNF(self, simplify: bool = True) -> 'And[Or[Var]]':
         """Compile theory to a semantically equivalent CNF formula."""
-        return tseitin.to_CNF(self, simplify_tautologies)
+        return tseitin.to_CNF(self, simplify)
 
     def _cnf_satisfiable(self) -> bool:
         """Call a SAT solver on the presumed CNF theory."""

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -574,9 +574,9 @@ class NNF(metaclass=abc.ABCMeta):
 
         return neg(self)
 
-    def to_CNF(self) -> 'And[Or[Var]]':
+    def to_CNF(self, simplify_tautologies=True) -> 'And[Or[Var]]':
         """Compile theory to a semantically equivalent CNF formula."""
-        return tseitin.to_CNF(self)
+        return tseitin.to_CNF(self, simplify_tautologies)
 
     def _cnf_satisfiable(self) -> bool:
         """Call a SAT solver on the presumed CNF theory."""

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -574,7 +574,7 @@ class NNF(metaclass=abc.ABCMeta):
 
         return neg(self)
 
-    def to_CNF(self, simplify_tautologies=True) -> 'And[Or[Var]]':
+    def to_CNF(self, simplify_tautologies: bool = True) -> 'And[Or[Var]]':
         """Compile theory to a semantically equivalent CNF formula."""
         return tseitin.to_CNF(self, simplify_tautologies)
 

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -575,7 +575,10 @@ class NNF(metaclass=abc.ABCMeta):
         return neg(self)
 
     def to_CNF(self, simplify: bool = True) -> 'And[Or[Var]]':
-        """Compile theory to a semantically equivalent CNF formula."""
+        """Compile theory to a semantically equivalent CNF formula.
+
+        :param simplify: If True, simplify clauses even if that means
+                     eliminating variables."""
         return tseitin.to_CNF(self, simplify)
 
     def _cnf_satisfiable(self) -> bool:

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -35,7 +35,7 @@ def to_CNF(theory: NNF, simplify_tautologies: bool = True) -> And[Or[Var]]:
 
         aux = Var.aux()
 
-        if any(~var in children for var in children):
+        if simplify_tautologies and any(~var in children for var in children):
             if isinstance(node, And):
                 clauses.append(Or({~aux}))
             else:

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -10,10 +10,11 @@ from nnf import NNF, Var, And, Or, Internal
 from nnf.util import memoize
 
 
-def to_CNF(theory: NNF, simplify_tautologies=True) -> And[Or[Var]]:
+def to_CNF(theory: NNF, simplify_tautologies: bool = True) -> And[Or[Var]]:
     """Convert an NNF into CNF using the Tseitin Encoding.
 
     :param theory: Theory to convert.
+    :param simplify_tautologies: If True, remove clauses that are always true.
     """
 
     clauses = []

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -14,7 +14,8 @@ def to_CNF(theory: NNF, simplify: bool = True) -> And[Or[Var]]:
     """Convert an NNF into CNF using the Tseitin Encoding.
 
     :param theory: Theory to convert.
-    :param simplify: If True, remove clauses that are always true.
+    :param simplify: If True, simplify clauses even if that means eliminating
+                     variables.
     """
 
     clauses = []

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -10,7 +10,7 @@ from nnf import NNF, Var, And, Or, Internal
 from nnf.util import memoize
 
 
-def to_CNF(theory: NNF) -> And[Or[Var]]:
+def to_CNF(theory: NNF, simplify_tautologies=True) -> And[Or[Var]]:
     """Convert an NNF into CNF using the Tseitin Encoding.
 
     :param theory: Theory to convert.
@@ -73,7 +73,7 @@ def to_CNF(theory: NNF) -> And[Or[Var]]:
 
         elif isinstance(node, Or):
             children = {process_node(c) for c in node.children}
-            if any(~var in children for var in children):
+            if simplify_tautologies and any(~var in children for var in children):
                 return
             clauses.append(Or(children))
 

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -73,7 +73,7 @@ def to_CNF(theory: NNF, simplify_tautologies=True) -> And[Or[Var]]:
 
         elif isinstance(node, Or):
             children = {process_node(c) for c in node.children}
-            if simplify_tautologies and any(~var in children for var in children):
+            if simplify_tautologies and any(~v in children for v in children):
                 return
             clauses.append(Or(children))
 

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -10,11 +10,11 @@ from nnf import NNF, Var, And, Or, Internal
 from nnf.util import memoize
 
 
-def to_CNF(theory: NNF, simplify_tautologies: bool = True) -> And[Or[Var]]:
+def to_CNF(theory: NNF, simplify: bool = True) -> And[Or[Var]]:
     """Convert an NNF into CNF using the Tseitin Encoding.
 
     :param theory: Theory to convert.
-    :param simplify_tautologies: If True, remove clauses that are always true.
+    :param simplify: If True, remove clauses that are always true.
     """
 
     clauses = []
@@ -35,7 +35,7 @@ def to_CNF(theory: NNF, simplify_tautologies: bool = True) -> And[Or[Var]]:
 
         aux = Var.aux()
 
-        if simplify_tautologies and any(~var in children for var in children):
+        if simplify and any(~var in children for var in children):
             if isinstance(node, And):
                 clauses.append(Or({~aux}))
             else:
@@ -74,7 +74,7 @@ def to_CNF(theory: NNF, simplify_tautologies: bool = True) -> And[Or[Var]]:
 
         elif isinstance(node, Or):
             children = {process_node(c) for c in node.children}
-            if simplify_tautologies and any(~v in children for v in children):
+            if simplify and any(~v in children for v in children):
                 return
             clauses.append(Or(children))
 

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -1107,6 +1107,21 @@ def test_models(sentence: nnf.NNF):
     assert model_set(real_models) == model_set(models)
 
 
+def test_tautology_simplification():
+    x = Var("x")
+    T = x | ~x
+
+    T1 = T.to_CNF()
+    T2 = T.to_CNF(simplify_tautologies=False)
+
+    assert T1 == nnf.true
+    assert T1.is_CNF()
+
+    assert T2 != nnf.true
+    assert T2 == And({Or({~x, x})})
+    assert T2.is_CNF()
+
+
 @config(auto_simplify=False)
 def test_nesting():
     a, b, c, d, e, f = Var("a"), Var("b"), Var("c"), Var("d"), \

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -1107,6 +1107,14 @@ def test_models(sentence: nnf.NNF):
     assert model_set(real_models) == model_set(models)
 
 
+@given(NNF())
+def test_tautology_simplification_names(sentence: nnf.NNF):
+    names1 = set(sentence.vars())
+    T = sentence.to_CNF(simplify_tautologies=False)
+    names2 = set({v for v in T.vars() if not isinstance(v, nnf.Aux)})
+    assert names1 == names2
+
+
 def test_tautology_simplification():
     x = Var("x")
     T = x | ~x

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -1108,19 +1108,19 @@ def test_models(sentence: nnf.NNF):
 
 
 @given(NNF())
-def test_tautology_simplification_names(sentence: nnf.NNF):
+def test_toCNF_simplification_names(sentence: nnf.NNF):
     names1 = set(sentence.vars())
-    T = sentence.to_CNF(simplify_tautologies=False)
+    T = sentence.to_CNF(simplify=False)
     names2 = set({v for v in T.vars() if not isinstance(v, nnf.Aux)})
     assert names1 == names2
 
 
-def test_tautology_simplification():
+def test_toCNF_simplification():
     x = Var("x")
     T = x | ~x
 
     T1 = T.to_CNF()
-    T2 = T.to_CNF(simplify_tautologies=False)
+    T2 = T.to_CNF(simplify=False)
 
     assert T1 == nnf.true
     assert T1.is_CNF()


### PR DESCRIPTION
Idea is to allow for tautologies in `to_CNF` conversions so that model counts aren't thrown off (variables mentioned in a tautological clause will be missing from the compilation).